### PR TITLE
Fix of undefined getGlobal('_viewRenderer')

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -148,9 +148,10 @@ class Extension
             // Inject code to re-register widget tag during run-time
             return <<<PHP
 <?php
-    \$_smarty_tpl->getGlobal('_viewRenderer')->widgets['blocks']['$alias'] = '$class';
+    \$viewRenderer=\$_smarty_tpl->default_template_handler_func[0];
+    \$viewRenderer->widgets['blocks']['$alias'] = '$class';
     try {
-        \$_smarty_tpl->registerPlugin('block', '$alias', [\$_smarty_tpl->getGlobal('_viewRenderer'), '_widget_block__$alias']);
+        \$_smarty_tpl->registerPlugin('block', '$alias', [\$viewRenderer, '_widget_block__$alias']);
     }
     catch (SmartyException \$e) {
         /* Ignore already registered exception during first execution after compilation */
@@ -165,9 +166,10 @@ PHP;
             // Inject code to re-register widget tag during run-time
             return <<<PHP
 <?php
-    \$_smarty_tpl->getGlobal('_viewRenderer')->widgets['functions']['$alias'] = '$class';
+    \$viewRenderer=\$_smarty_tpl->default_template_handler_func[0];
+    \$viewRenderer->widgets['functions']['$alias'] = '$class';
     try {
-        \$_smarty_tpl->registerPlugin('function', '$alias', [\$_smarty_tpl->getGlobal('_viewRenderer'), '_widget_function__$alias']);
+        \$_smarty_tpl->registerPlugin('function', '$alias', [\$viewRenderer, '_widget_function__$alias']);
     }
     catch (SmartyException \$e) {
         /* Ignore already registered exception during first execution after compilation */


### PR DESCRIPTION
Plugins registration in compiled php not working. Can't see any global vars with $_smarty_tpl->getGlobal()  except SCRIPT_NAME. Maybe problem in Smarty configuration but I have default. Looks like the ->default_template_handler_func[0] is the correct way to link to ViewRenderer
