### PR TITLE
fix error '_widget_func' to '_widget_function'

### DIFF
--- a/ViewRenderer.php
+++ b/ViewRenderer.php
@@ -159,7 +159,7 @@ class ViewRenderer extends BaseViewRenderer
         if (count($methodInfo) === 2) {
             $alias = $methodInfo[1];
             if (isset($this->widgets['functions'][$alias])) {
-                if (($methodInfo[0] === '_widget_func') && (count($args) === 2)) {
+                if (($methodInfo[0] === '_widget_function') && (count($args) === 2)) {
                     return $this->widgetFunction($this->widgets['functions'][$alias], $args[0], $args[1]);
                 }
             } elseif (isset($this->widgets['blocks'][$alias])) {


### PR DESCRIPTION
Here http://www.yiiframework.com/doc-2.0/guide-tutorial-template-engines.html

It works:

```php
'view' => [
    'renderers' => [
        'tpl' => [
            'class' => 'yii\smarty\ViewRenderer',
            'widgets' => [
                'functions' => [
                    'Nav' => 'yii\bootstrap\Nav',
                ],
            ],
        ],
    ],
],
```
But it does not work and throw exception 
`BadMethodCallException Method does not exist: _widget_function__Nav`

```php
{use class='yii\smarty\ViewRenderer' type='function'}
```

This pull request fix this error.