### PR TITLE
renaming the global registration too

### DIFF
--- a/ViewRenderer.php
+++ b/ViewRenderer.php
@@ -99,7 +99,7 @@ class ViewRenderer extends BaseViewRenderer
         // Register function widgets specified in configuration array
         if (isset($this->widgets['functions'])) {
             foreach(($this->widgets['functions']) as $tag => $class) {
-                $this->smarty->registerPlugin('function', $tag, [$this, '_widget_func__' . $tag]);
+                $this->smarty->registerPlugin('function', $tag, [$this, '_widget_function__' . $tag]);
                 $this->smarty->registerClass($tag, $class);
             }
         }


### PR DESCRIPTION
In the previous change you renamed widget_func to widget_function but the change was not done to the global registration too. So anything registered globally broke.