### PR TITLE
fixed bug --functionRegisterJsFile

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -320,9 +320,8 @@ PHP;
 
         $url = ArrayHelper::remove($params, 'url');
         $key = ArrayHelper::remove($params, 'key', null);
-        $position = ArrayHelper::remove($params, 'position');
         if (isset($params['position']))
-            $params['position'] = $this->getViewConstVal($position, View::POS_END);
+            $params['position'] = $this->getViewConstVal($params['position'], View::POS_END);
 
         Yii::$app->getView()->registerJsFile($url, $params, $key);
     }


### PR DESCRIPTION
`$position = ArrayHelper::remove($params, 'position');` the position is removed,`if (isset($params['position']))` always false.