### PR TITLE
Don't re-register blocks and functions during compile

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -136,6 +136,11 @@ class Extension
         $alias = ArrayHelper::getValue($params, 'as', StringHelper::basename($params['class']));
         $type = ArrayHelper::getValue($params, 'type', 'static');
 
+        // Skip already registered block and function
+        if (in_array($type, ['block', 'function']) && isset($this->smarty->registered_plugins[$type][$alias])) {
+            return;
+        }
+
         // Register the class during compile time
         $this->smarty->registerClass($alias, $class);
 
@@ -427,4 +432,4 @@ PHP;
       $val = @constant('yii\web\View::' . $string);
       return isset($val) ? $val : $default;
    }
-} 
+}

--- a/tests/ViewRendererTest.php
+++ b/tests/ViewRendererTest.php
@@ -97,6 +97,13 @@ class ViewRendererTest extends TestCase
         $view->renderFile('@yiiunit/extensions/smarty/views/use.tpl');
     }
 
+    public function testInheritedUse()
+    {
+        $view = $this->mockView();
+        $content = $view->renderFile('@yiiunit/extensions/smarty/views/use.tpl');
+        $view->renderFile('@yiiunit/extensions/smarty/views/extended-layout.tpl', ['content' => $content]);
+    }
+
     /**
      * @return View
      */

--- a/tests/views/extended-layout.tpl
+++ b/tests/views/extended-layout.tpl
@@ -1,0 +1,13 @@
+{use class='yii\widgets\Menu' type='function'}
+
+{$this->beginContent('@yiiunit/extensions/smarty/views/layout.tpl')|void}
+<div class="menu">
+    {Menu options=['class' => 'test'] items=[
+        ['label' => 'Home', 'url' => 'http://example.com/']
+    ]}
+</div>
+
+<div class="content">
+    {$content}
+</div>
+{$this->endContent()}


### PR DESCRIPTION
Fix SmartyException thrown when using multiple {use} for functions and blocks in inherited templates