### PR TITLE
Respect Widget Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 smarty extension Change Log
 2.0.8 under development
 -----------------------
 
-- no changes in this release.
+- Enh #31: Respect widget events (copies behavior of [Widget::end()](https://github.com/yiisoft/yii2/blob/master/framework/base/Widget.php#L108) method).
 
 
 2.0.7 April 25, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 smarty extension Change Log
 2.0.8 under development
 -----------------------
 
-- Enh #31: Respect widget events (copies behavior of [Widget::end()](https://github.com/yiisoft/yii2/blob/master/framework/base/Widget.php#L108) method).
+- Enh #31: Respect widget events (simialbi)
 
 
 2.0.7 April 25, 2018

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,10 @@
         "yiisoft/yii2": "~2.0.0",
         "smarty/smarty": "~3.1.0"
     },
+    "require-dev": {
+        "yiisoft/yii2-coding-standards": "~2.0",
+        "phpunit/phpunit": "*"
+    },
     "repositories": [
         {
             "type": "composer",
@@ -29,6 +33,11 @@
     ],
     "autoload": {
         "psr-4": {"yii\\smarty\\": "src"}
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "yiiunit\\smarty\\": "tests"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,11 @@
 {
     "name": "yiisoft/yii2-smarty",
     "description": "The Smarty integration for the Yii framework",
-    "keywords": ["yii2", "smarty", "renderer"],
+    "keywords": [
+        "yii2",
+        "smarty",
+        "renderer"
+    ],
     "type": "yii2-extension",
     "license": "BSD-3-Clause",
     "support": {
@@ -32,7 +36,9 @@
         }
     ],
     "autoload": {
-        "psr-4": {"yii\\smarty\\": "src"}
+        "psr-4": {
+            "yii\\smarty\\": "src"
+        }
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -212,7 +212,13 @@ class ViewRenderer extends BaseViewRenderer
         } else {
             $widget = array_pop(Widget::$stack);
             echo $content;
-            $out = $widget->run();
+            if ($widget->beforeRun()) { // respect $event->isValid even here
+                $out = $widget->run();
+                $out = $widget->afterRun($out);
+            } else {
+                $out = '';
+            }
+            
             return ob_get_clean() . $out;
         }
     }

--- a/tests/ViewRendererTest.php
+++ b/tests/ViewRendererTest.php
@@ -133,6 +133,18 @@ class ViewRendererTest extends TestCase
         $this->assertTrue(strpos($content, date('Ymd')) !== false, 'A date should be there: ' . $content);
     }
 
+    public function testWidgetDefault() {
+        $view = $this->mockView();
+        $content = $view->renderFile('@yiiunit/smarty/views/widget-default.tpl');
+        $this->assertContains('<div class="widget">test</div>', $content);
+    }
+
+    public function testWidgetHidden() {
+        $view = $this->mockView();
+        $content = $view->renderFile('@yiiunit/smarty/views/widget-invalid.tpl');
+        $this->assertNotContains('<div class="widget">test</div>', $content);
+    }
+
     /**
      * @return View
      */

--- a/tests/ViewRendererTest.php
+++ b/tests/ViewRendererTest.php
@@ -55,7 +55,9 @@ class ViewRendererTest extends TestCase
         $view = $this->mockView();
         $content = $view->renderFile('@yiiunit/smarty/views/layout.tpl');
 
-        $this->assertEquals(1, preg_match('#<script src="/assets/[0-9a-z]+/jquery\\.js"></script>\s*</body>#', $content), 'Content does not contain the jquery js:' . $content);
+        $this->assertEquals(1,
+            preg_match('#<script src="/assets/[0-9a-z]+/jquery\\.js"></script>\s*</body>#', $content),
+            'Content does not contain the jquery js:' . $content);
     }
 
 
@@ -66,7 +68,8 @@ class ViewRendererTest extends TestCase
 
         $content = $view->renderFile('@yiiunit/smarty/views/changeTitle.tpl');
         $this->assertTrue(strpos($content, 'New title') !== false, 'New title should be there:' . $content);
-        $this->assertFalse(strpos($content, 'Original title') !== false, 'Original title should not be there:' . $content);
+        $this->assertFalse(strpos($content, 'Original title') !== false,
+            'Original title should not be there:' . $content);
     }
 
     public function testForm()
@@ -74,21 +77,27 @@ class ViewRendererTest extends TestCase
         $view = $this->mockView();
         $model = new Singer();
         $content = $view->renderFile('@yiiunit/smarty/views/form.tpl', ['model' => $model]);
-        $this->assertEquals(1, preg_match('#<form id="login-form" class="form-horizontal" action="/form-handler" method="post">.*?</form>#s', $content), 'Content does not contain form:' . $content);
+        $this->assertEquals(1,
+            preg_match('#<form id="login-form" class="form-horizontal" action="/form-handler" method="post">.*?</form>#s',
+                $content), 'Content does not contain form:' . $content);
     }
 
     public function testInheritance()
     {
         $view = $this->mockView();
         $content = $view->renderFile('@yiiunit/smarty/views/extends2.tpl');
-        $this->assertTrue(strpos($content, 'Hello, I\'m inheritance test!') !== false, 'Hello, I\'m inheritance test! should be there:' . $content);
+        $this->assertTrue(strpos($content, 'Hello, I\'m inheritance test!') !== false,
+            'Hello, I\'m inheritance test! should be there:' . $content);
         $this->assertTrue(strpos($content, 'extends2 block') !== false, 'extends2 block should be there:' . $content);
-        $this->assertFalse(strpos($content, 'extends1 block') !== false, 'extends1 block should not be there:' . $content);
+        $this->assertFalse(strpos($content, 'extends1 block') !== false,
+            'extends1 block should not be there:' . $content);
 
         $content = $view->renderFile('@yiiunit/smarty/views/extends3.tpl');
-        $this->assertTrue(strpos($content, 'Hello, I\'m inheritance test!') !== false, 'Hello, I\'m inheritance test! should be there:' . $content);
+        $this->assertTrue(strpos($content, 'Hello, I\'m inheritance test!') !== false,
+            'Hello, I\'m inheritance test! should be there:' . $content);
         $this->assertTrue(strpos($content, 'extends3 block') !== false, 'extends3 block should be there:' . $content);
-        $this->assertFalse(strpos($content, 'extends1 block') !== false, 'extends1 block should not be there:' . $content);
+        $this->assertFalse(strpos($content, 'extends1 block') !== false,
+            'extends1 block should not be there:' . $content);
     }
 
     public function testUse()
@@ -133,13 +142,15 @@ class ViewRendererTest extends TestCase
         $this->assertTrue(strpos($content, date('Ymd')) !== false, 'A date should be there: ' . $content);
     }
 
-    public function testWidgetDefault() {
+    public function testWidgetDefault()
+    {
         $view = $this->mockView();
         $content = $view->renderFile('@yiiunit/smarty/views/widget-default.tpl');
         $this->assertContains('<div class="widget">test</div>', $content);
     }
 
-    public function testWidgetHidden() {
+    public function testWidgetHidden()
+    {
         $view = $this->mockView();
         $content = $view->renderFile('@yiiunit/smarty/views/widget-invalid.tpl');
         $this->assertNotContains('<div class="widget">test</div>', $content);

--- a/tests/views/widget-default.tpl
+++ b/tests/views/widget-default.tpl
@@ -1,0 +1,3 @@
+{use class="yiiunit\smarty\widgets\DemoWidget" type="function"}
+
+<div class="widget">{DemoWidget}</div>

--- a/tests/views/widget-invalid.tpl
+++ b/tests/views/widget-invalid.tpl
@@ -1,0 +1,3 @@
+{use class="yiiunit\smarty\widgets\DemoWidget" type="function"}
+
+<div class="widget">{DemoWidget hidden=true}</div>

--- a/tests/widgets/DemoWidget.php
+++ b/tests/widgets/DemoWidget.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package yii2-smarty
+ * @author Simon Karlen <simi.albi@gmail.com>
+ */
+
+namespace yiiunit\smarty\widgets;
+
+
+use yii\base\Widget;
+
+class DemoWidget extends Widget {
+    /**
+     * @var boolean Prevent
+     */
+    public $hidden = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function init() {
+        parent::init();
+
+        if ($this->hidden) {
+            $this->on(self::EVENT_BEFORE_RUN, function ($event) {
+                /* @var $event \yii\base\WidgetEvent */
+
+                $event->isValid = false;
+            });
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run() {
+        return 'test';
+    }
+}

--- a/tests/widgets/DemoWidget.php
+++ b/tests/widgets/DemoWidget.php
@@ -9,7 +9,8 @@ namespace yiiunit\smarty\widgets;
 
 use yii\base\Widget;
 
-class DemoWidget extends Widget {
+class DemoWidget extends Widget
+{
     /**
      * @var boolean Prevent
      */
@@ -18,7 +19,8 @@ class DemoWidget extends Widget {
     /**
      * {@inheritdoc}
      */
-    public function init() {
+    public function init()
+    {
         parent::init();
 
         if ($this->hidden) {
@@ -33,7 +35,8 @@ class DemoWidget extends Widget {
     /**
      * {@inheritdoc}
      */
-    public function run() {
+    public function run()
+    {
         return 'test';
     }
 }


### PR DESCRIPTION
The smarty view renderer ignores the `EVENT_BEFORE_RUN` and `EVENT_AFTER_RUN` `isValid` return value.
With this change it copies the behavior of [Widget::end()](https://github.com/yiisoft/yii2/blob/master/framework/base/Widget.php#L108) method.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none
