### PR TITLE
Обновили файлик  с заменой set на add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,10 @@
 Yii Framework 2 smarty extension Change Log
 ===========================================
 
-2.0.11 
-----------------------------------------
-- Bug #38: Change call of Smarty method setTemplateDir to addTemplateDir (alex-net)
-
-
 2.0.10 under development
 ------------------------
 
-- no changes in this release.
+- Bug #38: Change call of Smarty method `setTemplateDir()` to `addTemplateDir()` (alex-net)
 
 
 2.0.9 November 19, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Yii Framework 2 smarty extension Change Log
 ===========================================
 
+2.0.11 
+----------------------------------------
+- Bug #38: Change call of Smarty method setTemplateDir to addTemplateDir (alex-net)
+
+
 2.0.10 under development
 ------------------------
 

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -79,7 +79,7 @@ class ViewRenderer extends BaseViewRenderer
             $this->smarty->$key = $value;
         }
 
-        $this->smarty->setTemplateDir([
+        $this->smarty->addTemplateDir([
             dirname(Yii::$app->getView()->getViewFile()),
             Yii::$app->getViewPath(),
         ]);


### PR DESCRIPTION
Причина изменений .. =  у класса есть свойство options,  через которое можно настраивать Smarty ..   Интересует опция  template_dir для прописывания путей к шаблонам Smarty https://www.smarty.net/docs/en/variable.template.dir.tpl Эта опция может быть массивом. Но её заданию мешает вызов setTemplateDir, который глушит все труды описанные в options,  то есть просто замена набора каталогов . на 2 .. 
Если заменить вызов на addTemplateDir,  то этот набор будет дополнен ещё двумя путями..

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
