### PR TITLE
Fixed registerJs and registerCss Blocks in PHP 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 smarty extension Change Log
 2.0.10 under development
 ------------------------
 
-Bug #39: Fixed fetching View constant values for `registerJs` and `registerCss` blocks in PHP 8 (simialbi)
+- Bug #39: Fixed fetching View constant values for `registerJs` and `registerCss` blocks in PHP 8 (simialbi)
 - Bug #38: Change call of Smarty method `setTemplateDir()` to `addTemplateDir()` (alex-net)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 smarty extension Change Log
 2.0.10 under development
 ------------------------
 
-- Bug #39: Fix `registerJs` and `registerCss` Blocks in PHP 8 (simialbi)
+Bug #39: Fixed fetching View constant values for `registerJs` and `registerCss` blocks in PHP 8 (simialbi)
 - Bug #38: Change call of Smarty method `setTemplateDir()` to `addTemplateDir()` (alex-net)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 smarty extension Change Log
 2.0.10 under development
 ------------------------
 
+- Bug #39: Fix `registerJs` and `registerCss` Blocks in PHP 8 (simialbi)
 - Bug #38: Change call of Smarty method `setTemplateDir()` to `addTemplateDir()` (alex-net)
 
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -456,11 +456,7 @@ PHP;
      */
     protected function getViewConstVal($string, $default)
     {
-        try {
-            $val = @constant('yii\web\View::' . $string);
-        } catch (\Exception $e) {
-        } finally {
-            return isset($val) ? $val : $default;
-        }
+        $r = new \ReflectionClass('\yii\web\View');
+        return (false !== ($val = $r->getConstant($string))) ? $val : $default;
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -77,7 +77,7 @@ class Extension
             trigger_error("path: missing 'route' parameter");
         }
 
-        array_unshift($params, $params['route']) ;
+        array_unshift($params, $params['route']);
         unset($params['route']);
 
         return Url::to($params);
@@ -103,7 +103,7 @@ class Extension
             trigger_error("path: missing 'route' parameter");
         }
 
-        array_unshift($params, $params['route']) ;
+        array_unshift($params, $params['route']);
         unset($params['route']);
 
         return Url::to($params, true);
@@ -186,6 +186,8 @@ PHP;
 ?>
 PHP;
         }
+
+        return '';
     }
 
     /**
@@ -212,7 +214,6 @@ PHP;
      *
      * @param $params
      * @param \Smarty_Internal_Template $template
-     * @return string
      * @note Even though this method is public it should not be called directly.
      */
     public function functionSet($params, $template)
@@ -244,7 +245,6 @@ PHP;
      *
      * @param $params
      * @param \Smarty_Internal_Template $template
-     * @return string
      * @note Even though this method is public it should not be called directly.
      */
     public function functionMeta($params, $template)
@@ -264,7 +264,6 @@ PHP;
      * @param array $params
      * @param \Smarty_Internal_Template $template
      *
-     * @return string
      * @since 2.0.9
      */
     public function functionJs($params, \Smarty_Internal_Template $template)
@@ -292,7 +291,6 @@ PHP;
      * @param $content
      * @param \Smarty_Internal_Template $template
      * @param $repeat
-     * @return string
      * @note Even though this method is public it should not be called directly.
      */
     public function blockTitle($params, $content, $template, &$repeat)
@@ -317,7 +315,6 @@ PHP;
      * @param $content
      * @param \Smarty_Internal_Template $template
      * @param $repeat
-     * @return string
      * @note Even though this method is public it should not be called directly.
      */
     public function blockDescription($params, $content, $template, &$repeat)
@@ -326,9 +323,10 @@ PHP;
             // Clean-up whitespace and newlines
             $content = preg_replace('/\s+/', ' ', trim($content));
 
-            Yii::$app->getView()->registerMetaTag(['name' => 'description',
-                                                   'content' => $content],
-                                                   'description');
+            Yii::$app->getView()->registerMetaTag([
+                'name' => 'description',
+                'content' => $content
+            ], 'description');
         }
     }
 
@@ -345,7 +343,6 @@ PHP;
      *
      * @param $params
      * @param \Smarty_Internal_Template $template
-     * @return string
      * @note Even though this method is public it should not be called directly.
      */
     public function functionRegisterJsFile($params, $template)
@@ -379,7 +376,6 @@ PHP;
      * @param $content
      * @param \Smarty_Internal_Template $template
      * @param $repeat
-     * @return string
      * @note Even though this method is public it should not be called directly.
      */
     public function blockJavaScript($params, $content, $template, &$repeat)
@@ -388,9 +384,11 @@ PHP;
             $key = isset($params['key']) ? $params['key'] : null;
             $position = isset($params['position']) ? $params['position'] : null;
 
-            Yii::$app->getView()->registerJs($content,
-                                             $this->getViewConstVal($position, View::POS_READY),
-                                             $key);
+            Yii::$app->getView()->registerJs(
+                $content,
+                $this->getViewConstVal($position, View::POS_READY),
+                $key
+            );
         }
     }
 
@@ -405,7 +403,6 @@ PHP;
      *
      * @param $params
      * @param \Smarty_Internal_Template $template
-     * @return string
      * @note Even though this method is public it should not be called directly.
      */
     public function functionRegisterCssFile($params, $template)
@@ -438,7 +435,6 @@ PHP;
      * @param $content
      * @param \Smarty_Internal_Template $template
      * @param $repeat
-     * @return string
      * @note Even though this method is public it should not be called directly.
      */
     public function blockCss($params, $content, $template, &$repeat)
@@ -458,9 +454,10 @@ PHP;
      * @param int $default Default value
      * @return mixed
      */
-   protected function getViewConstVal($string, $default)
-   {
-      $val = @constant('yii\web\View::' . $string);
-      return isset($val) ? $val : $default;
-   }
+    protected function getViewConstVal($string, $default)
+    {
+        $val = @constant('yii\web\View::' . $string);
+
+        return isset($val) ? $val : $default;
+    }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -456,8 +456,10 @@ PHP;
      */
     protected function getViewConstVal($string, $default)
     {
-        $val = @constant('yii\web\View::' . $string);
-
-        return isset($val) ? $val : $default;
+        try {
+            $val = @constant('yii\web\View::' . $string);
+        } finally {
+            return isset($val) ? $val : $default;
+        }
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -459,8 +459,8 @@ PHP;
         try {
             $val = @constant('yii\web\View::' . $string);
         } catch (\Exception $e) {
+        } finally {
+            return isset($val) ? $val : $default;
         }
-
-        return isset($val) ? $val : $default;
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -456,7 +456,16 @@ PHP;
      */
     protected function getViewConstVal($string, $default)
     {
+        /*
         $r = new \ReflectionClass('\yii\web\View');
-        return ($r->hasConstant($string)) ? $r->getConstant($string) : $default;
+        return $r->hasConstant($string) ? $r->getConstant($string) : $default;
+        /*/
+        try {
+            $val = @constant('\yii\web\View::' . $string);
+        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+        }
+
+        return isset($val) ? $val : $default;
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -457,6 +457,6 @@ PHP;
     protected function getViewConstVal($string, $default)
     {
         $r = new \ReflectionClass('\yii\web\View');
-        return (false !== ($val = $r->getConstant($string))) ? $val : $default;
+        return ($r->hasConstant($string)) ? $r->getConstant($string) : $default;
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -458,8 +458,9 @@ PHP;
     {
         try {
             $val = @constant('yii\web\View::' . $string);
-        } finally {
-            return isset($val) ? $val : $default;
+        } catch (\Exception $e) {
         }
+
+        return isset($val) ? $val : $default;
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -456,10 +456,6 @@ PHP;
      */
     protected function getViewConstVal($string, $default)
     {
-        /*
-        $r = new \ReflectionClass('\yii\web\View');
-        return $r->hasConstant($string) ? $r->getConstant($string) : $default;
-        /*/
         try {
             $val = @constant('\yii\web\View::' . $string);
         } catch (\Exception $e) {

--- a/tests/ViewRendererTest.php
+++ b/tests/ViewRendererTest.php
@@ -9,6 +9,7 @@ namespace yiiunit\smarty;
 
 use yii\helpers\FileHelper;
 use yii\web\AssetManager;
+use yii\web\Controller;
 use yii\web\View;
 use Yii;
 use yiiunit\smarty\data\Singer;
@@ -154,6 +155,25 @@ class ViewRendererTest extends TestCase
         $view = $this->mockView();
         $content = $view->renderFile('@yiiunit/smarty/views/widget-invalid.tpl');
         $this->assertNotContains('<div class="widget">test</div>', $content);
+    }
+
+    public function testRegisterBlocks()
+    {
+        $view = Yii::$app->view;
+        $view->renderers['tpl'] = [
+            'class' => '\yii\smarty\ViewRenderer',
+            'options' => ['force_compile' => true]
+        ];
+        $content = $view->render('@yiiunit/smarty/views/register-blocks.tpl');
+        $content = $view->renderFile('@yiiunit/smarty/views/layout-block.tpl', ['content' => $content]);
+        $this->assertContains('<script>jQuery(function ($) {
+    console.log(\'test\');
+
+});</script>', $content);
+        $this->assertContains('<style>    body {
+        background-color: white;
+    }
+</style>', $content);
     }
 
     /**

--- a/tests/views/layout-block.tpl
+++ b/tests/views/layout-block.tpl
@@ -1,0 +1,15 @@
+{$this->beginPage()}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="{$app->charset}"/>
+        <title>{$this->title|escape}</title>
+        {$this->head()}
+    </head>
+    <body>
+        {$this->beginBody()}
+        {$content}
+        {$this->endBody()}
+    </body>
+    {$this->endPage()}
+</html>

--- a/tests/views/register-blocks.tpl
+++ b/tests/views/register-blocks.tpl
@@ -1,0 +1,8 @@
+{registerJs}
+    console.log('test');
+{/registerJs}
+{registerCss}
+    body {ldelim}
+        background-color: white;
+    {rdelim}
+{/registerCss}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️ 
| New feature?  | ❌ 
| Breaks BC?    | ❌ 
| Tests pass?   | ✔️ 
| Fixed issues  | 

There is an error with the registerJs and registerCss blocks in PHP 8, because the "constant" method throws an error and not a warning any more and the @ operator does not supresses errors any more (see https://github.com/simialbi/yii2-smarty/runs/2684050074?check_suite_focus=true and https://www.php.net/releases/8.0/en.php below `Type system and error handling improvements`). 
I replaced with ReflectionClass, what's more expensive, but failsafe with all versions (see https://github.com/simialbi/yii2-smarty/runs/2684191755?check_suite_focus=true). The other variant is to drop php 5.4 support and solve it with `try` / `finally` (see https://github.com/simialbi/yii2-smarty/actions/runs/881826868)
I additionaly removed `@return` comments on non returning methods and optimized code style a bit.